### PR TITLE
COMPASS-224 don’t assume “cursor” field in legacy response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs-v2.3.4'
+  - 6
 before_install:
   - npm install -g npm@3
   - npm config set loglevel error
@@ -11,7 +11,4 @@ script: npm run-script ci
 cache:
   directories:
     - node_modules
-# Post build notifications to the Integrations Flowdock
-notifications:
-  flowdock: e3dc17bc8a2c1b3412abe3e5747f8291
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/lib/legacy-model.js
+++ b/lib/legacy-model.js
@@ -25,7 +25,8 @@ var LegacyExplainPlanModel = Model.extend({
       deps: ['rawExplainObject'],
       fn: function() {
         // for unsharded explain plan
-        var mtch = this.rawExplainObject.cursor.match(/BTreeCursor (\S+)$/);
+        var cursor = _.get(this.rawExplainObject, 'cursor', null);
+        var mtch = cursor && cursor.match(/BTreeCursor (\S+)$/);
         return mtch ? mtch[1] : null;
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "devDependencies": {
     "debug": "^2.2.0",
-    "eslint-config-mongodb-js": "^1.0.6",
-    "mocha": "^2.3.4",
+    "eslint-config-mongodb-js": "^2.2.0",
+    "mocha": "^3.1.2",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.8",
     "pre-commit": "^1.1.2"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -144,6 +144,15 @@ describe('explain-plan-model', function() {
         model = loadExplainFixture('./fixtures/simple_collscan_2.6.json');
         assert.ok(!model.isSharded);
       });
+
+      it('should not assume that there is a cursor field (COMPASS-224)', function() {
+        explain = require('./fixtures/sharded_query_2.6.json');
+        delete explain.cursor;
+        assert.doesNotThrow(function() {
+          model = new ExplainPlanModel(explain, {parse: true});
+          assert.equal(model.usedIndex, null);
+        });
+      });
     });
 
     describe('Simple collection scans', function() {


### PR DESCRIPTION
I haven't seen a response without a `cursor` field personally, but from Bugsnag, it appears that some responses do not have it. We assumed it's always present. 

This change checks first before executing the `cursor.match()`.

Also added a test for this situation.